### PR TITLE
Add user addons migration

### DIFF
--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -54,6 +54,9 @@ func (a *Agent) Do(ctx context.Context) error {
 		if err := migrationconfig.MigrateAddonsConfig(ctx, a.fullState, a.dataDir); err != nil {
 			return err
 		}
+		if err := migrationconfig.MigrateUserAddonsConfig(ctx, a.fullState, a.dataDir, a.sc.Core.Core().V1().ConfigMap()); err != nil {
+			return err
+		}
 	}
 
 	if a.isETCD && !a.disableETCDRestore {


### PR DESCRIPTION
The PR will allow user addons migration, user addons are divided into two sections:

- user_addons:
This parameter accept a yaml string of the addon object that will be deployed on the system, and this yaml string will be stored as is in the cluster.rkestate file

- user_addons_includes:

This is a list of urls and paths on disk that will be parsed and deployed on the system, the urls and paths are **not** stored in cluster.rkestate file, however its stored in the configmap with the same name.

The pr will copy the content of user addons from the rkestate file and copy it to server manifests, and will also copy the content of the configmap for user addons includes and copy it to server manifests as well. 